### PR TITLE
update apache/superset:latest-dev and authlib

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,13 @@
-FROM apache/superset:3.0.0rc3
+FROM apache/superset:latest-dev
 
 USER root
+
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get clean
+
 RUN pip install --trusted-host pypi.org --trusted-host files.pythonhosted.org --upgrade pip setuptools
-RUN pip install --trusted-host pypi.org --trusted-host files.pythonhosted.org psycopg2 pyhive elasticsearch-dbapi ibm_db_sa sqlalchemy-trino authlib certifi
+RUN pip install --trusted-host pypi.org --trusted-host files.pythonhosted.org psycopg2 pyhive elasticsearch-dbapi ibm_db_sa sqlalchemy-trino authlib
 
 RUN chown -R superset /usr/local/share/ca-certificates/ && \
     chown -R superset /etc/ssl/certs && \


### PR DESCRIPTION
- Update to superset:latest-dev
- cetifi in newer image already in latest version required from apache-superset 0.0.0.dev0
- need to scan in aquascan for further checks